### PR TITLE
fix: move rollup plugins to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
   },
   "homepage": "https://docs.swetrix.com",
   "dependencies": {
-    "@rollup/plugin-terser": "^0.4.4",
-    "@rollup/plugin-typescript": "^12.1.1",
     "@types/node": "^22.8.6",
     "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",
+    "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-typescript": "^12.1.1",
     "rimraf": "^6.0.1",
     "rollup": "^4.24.3",
     "typescript": "^5.6.3"


### PR DESCRIPTION
You probably don't need @types/node or tslib either, they don't appear to be used anywhere.